### PR TITLE
[!!!][TASK] Remove obsolete dependencies

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -37,10 +37,7 @@ $EM_CONF[$_EXTKEY] = [
 	'CGLcompliance_note' => '',
 	'constraints' => [
 		'depends' => [
-			'typo3' => '6.0.0-9.5.99',
-			'extbase' => '6.0.0-9.5.99',
-			'fluid' => '6.0.0-9.5.99',
-			'cms' => '',
+			'typo3' => '7.6.0-9.5.99',
 			'php' => '5.5.0-0.0.0'
 		],
 		'conflicts' => [],


### PR DESCRIPTION
PHP Deprecated: Extension "typoscript2ce" defines a dependency on ext:cms, which has been removed. Please remove the dependency.
see ...\web\typo3\sysext\core\Classes\Package\Package.php on line 133

This patch removes the dependency to ext:cms, which has been [removed in TYPO3 7.4](https://docs.typo3.org/typo3cms/extensions/core/Changelog/7.4/Deprecation-67991-RemovedExtCms.html).

In addition, the dependencies to fluid and extbase are also removed.