### PR TITLE
[TASK] Move TCA modifications to Configuration/TCA/Overrides

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,7 +1,4 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
 /**
  * Include Plugins


### PR DESCRIPTION
Since TYPO3 CMS 6.2 changes to $GLOBALS['TCA'] must be stored inside a
folder called Configuration/TCA/Overrides