### PR TITLE
[TASK] Add TYPO3 12 compatibility

### DIFF
--- a/Classes/Controller/TypoScriptController.php
+++ b/Classes/Controller/TypoScriptController.php
@@ -1,6 +1,7 @@
 <?php
 namespace In2code\Typoscript2ce\Controller;
 
+use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 /**
@@ -9,9 +10,10 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 class TypoScriptController extends ActionController
 {
     /**
-     * @return void
+     * @return ResponseInterface
      */
-    public function indexAction()
+    public function indexAction(): ResponseInterface
     {
+        return $this->htmlResponse();
     }
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,8 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  In2code\Typoscript2ce\:
+    resource: '../Classes/*'

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "type": "typo3-cms-extension",
   "license": "GPL-3.0",
   "require": {
-    "typo3/cms-core": ">=10.4.0 <12.0.0"
+    "typo3/cms-core": ">=11.5.0 <13.0.0"
   },
   "replace": {
     "typo3-ter/typoscript2ce": "self.version"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => 'in2code.de',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.0.0-11.5.99'
+            'typo3' => '11.5.0-12.4.99'
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('TYPO3_MODE')) {
+if (!defined('TYPO3')) {
     die('Access denied.');
 }
 


### PR DESCRIPTION
We have tested it with TYPO3 12.0.0 and this changes are at least needed to work.

Sources:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Deprecation-92947-DeprecateTYPO3_MODEAndTYPO3_REQUESTTYPEConstants.html
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96107-DeprecatedFunctionalityRemoved.html
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Deprecation-92784-ExtbaseControllerActionsMustReturnResponseInterface.html