### PR TITLE
[TASK] Add TYPO3 13 compatibility

### DIFF
--- a/Configuration/FlexForms/FlexFormPi1.xml
+++ b/Configuration/FlexForms/FlexFormPi1.xml
@@ -5,21 +5,17 @@
 	<sheets>
 		<main>
 			<ROOT>
-				<TCEforms>
-					<sheetTitle>LLL:EXT:typoscript2ce/Resources/Private/Language/locallang_db.xlf:flexform.main</sheetTitle>
-				</TCEforms>
+				<sheetTitle>LLL:EXT:typoscript2ce/Resources/Private/Language/locallang_db.xlf:flexform.main</sheetTitle>
 				<type>array</type>
 				<el>
 					<settings.typoscriptobjectpath>
-						<TCEforms>
-							<exclude>1</exclude>
-							<label>LLL:EXT:typoscript2ce/Resources/Private/Language/locallang_db.xlf:flexform.typoscriptobjectpath</label>
-							<config>
-								<type>input</type>
-								<size>50</size>
-								<eval>trim</eval>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<label>LLL:EXT:typoscript2ce/Resources/Private/Language/locallang_db.xlf:flexform.typoscriptobjectpath</label>
+						<config>
+							<type>input</type>
+							<size>50</size>
+							<eval>trim</eval>
+						</config>
 					</settings.typoscriptobjectpath>
 				</el>
 			</ROOT>

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "type": "typo3-cms-extension",
   "license": "GPL-3.0",
   "require": {
-    "typo3/cms-core": "^11.5 || ^12.0"
+    "typo3/cms-core": "^12.4 || ^13.0"
   },
   "replace": {
     "typo3-ter/typoscript2ce": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "type": "typo3-cms-extension",
   "license": "GPL-3.0",
   "require": {
-    "typo3/cms-core": "^12.4 || ^13.0"
+    "typo3/cms-core": "^11.5 || ^12.4 || ^13.0"
   },
   "replace": {
     "typo3-ter/typoscript2ce": "self.version"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => 'in2code.de',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-12.4.99'
+            'typo3' => '12.4.0-13.4.99'
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => 'in2code.de',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-13.4.99'
+            'typo3' => '11.5.0-13.4.99'
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
We have tested it with TYPO3 13.3.0 and this changes are at least needed to work. Could you release a new version in TER please? :-)

Sources:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Deprecation-97126-TCEformsRemovedInFlexForm.html
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-100963-DeprecatedFunctionalityRemoved.html